### PR TITLE
Add Cursor Cloud development environment documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+VerKeL is a single Rails 8 monolith (Ruby 3.4.8, PostgreSQL, Yarn/Webpack + Sass). See `README.md` for the basics; this section covers non-obvious Cloud VM details.
+
+### System prerequisites (one-time per VM)
+
+- **Ruby 3.4.8** via rbenv (see `.ruby-version`). Ensure `~/.bashrc` initializes rbenv (`eval "$(rbenv init - bash)"`).
+- **PostgreSQL 18** (required): `db/structure.sql` sets `transaction_timeout`, which needs PG 17+. CI uses `postgres:18-alpine`. Ubuntu’s default PG 16 package is insufficient for `bin/rails db:prepare` / `db:schema:load`.
+  - Start before Rails commands: `sudo pg_ctlcluster 18 main start` (cluster must listen on port **5432** for default `config/database.yml`).
+  - Dev credentials used in CI and locally: `DATABASE_USER=postgres`, `DATABASE_PASSWORD=postgres`, `DATABASE_HOST=127.0.0.1`.
+
+### Environment variables
+
+Export for Rails, tests, and `bin/dev`:
+
+```bash
+export DATABASE_USER=postgres DATABASE_PASSWORD=postgres DATABASE_HOST=127.0.0.1
+```
+
+Optional `.env` is supported via `dotenv-rails` (gitignored).
+
+### Dependencies and database
+
+```bash
+bundle install
+yarn install
+yarn build && yarn build:css   # required before first server start; gitignored under app/assets/builds/
+bin/rails db:prepare
+bin/rails db:seed              # admin@example.com / admin + sample Kochgruppen/Meals
+```
+
+`bin/setup` runs bundle + `db:prepare` and can start `bin/dev` (omit `--skip-server` only when you want the server immediately).
+
+### Running the app (development)
+
+Use **Foreman** via `bin/dev` (`Procfile.dev`: Rails on port 3000, `yarn build --watch`, `yarn build:css --watch`). Foreman is installed on first `bin/dev` run.
+
+Without Foreman, run all three processes in separate terminals.
+
+### Lint / test
+
+| Task | Command |
+|------|---------|
+| Lint | `bin/rubocop` (many existing offenses; CI does not run RuboCop) |
+| Tests | `bin/rspec` or `bin/rake` with `RAILS_ENV=test` after `bin/rails db:schema:load` |
+
+Tests only need PostgreSQL; they do not need asset watchers.
+
+### Seeded demo login
+
+After `db:seed`: **admin@example.com** / **admin**. Core UI routes include `/groups` (Kochgruppen) and `/meals` (Menü).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents how to run the VerKeL Rails app in Cursor Cloud VMs after the initial environment setup.

## Changes

- Adds `AGENTS.md` with Cloud-specific instructions: PostgreSQL 18 requirement, rbenv Ruby 3.4.8, database env vars, asset builds, `bin/dev`, lint/test commands, and seeded admin login.

## Verification (this session)

- `bundle install`, `yarn install`, `yarn build`, `yarn build:css`
- `bin/rails db:prepare` + `db:seed`
- `bin/rspec`: **82 examples, 0 failures**
- `bin/rubocop`: runs (existing offenses in repo)
- `bin/dev` on port 3000; logged in as `admin@example.com` and browsed Kochgruppen + Menü

[Authenticated Kochgruppen page](https://cursor.com/agents/bc-82097471-f6c7-4040-8953-f694141c53b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverkel-groups-authenticated.webp)

[verkel-login-and-groups-demo.mp4](https://cursor.com/agents/bc-82097471-f6c7-4040-8953-f694141c53b1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fverkel-login-and-groups-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82097471-f6c7-4040-8953-f694141c53b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82097471-f6c7-4040-8953-f694141c53b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

