### PR TITLE
Fix "new" buttons hidden behind DataTable search box

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,6 +1,8 @@
-<div class="btn-group float-end" role="group">
-  <%= link_to 'Inventurliste', inventory_list_articles_path(format: 'pdf'), class: 'btn btn-sm btn-secondary' %>
-  <%= link_to 'Neuen Artikel anlegen', new_article_path, class: 'btn btn-sm btn-primary' %>
+<div class="d-flex justify-content-end mb-2 mt-4">
+  <div class="btn-group" role="group">
+    <%= link_to 'Inventurliste', inventory_list_articles_path(format: 'pdf'), class: 'btn btn-sm btn-secondary' %>
+    <%= link_to 'Neuen Artikel anlegen', new_article_path, class: 'btn btn-sm btn-primary' %>
+  </div>
 </div>
 
 <%= render 'table', articles: @articles %>

--- a/app/views/ingredients/show.html.erb
+++ b/app/views/ingredients/show.html.erb
@@ -68,7 +68,9 @@
 
 <h2>Lieferanten</h2>
 
-<%= link_to 'Neuen Artikel anlegen', new_article_path(ingredient_id: @ingredient), class: 'btn btn-sm btn-primary float-end' %>
+<div class="d-flex justify-content-end mb-2 mt-4">
+  <%= link_to 'Neuen Artikel anlegen', new_article_path(ingredient_id: @ingredient), class: 'btn btn-sm btn-primary' %>
+</div>
 <%= render 'articles/table', articles: @ingredient.articles, ingredient: true, show_price: true %>
 
 <table class="table table-sm">

--- a/app/views/participants/index.html.erb
+++ b/app/views/participants/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Teilnehmende</h1>
 
-<%= link_to 'Neue Teilnehmer*in anlegen', new_participant_path, class: 'btn btn-primary btn-sm float-end' %>
+<div class="d-flex justify-content-end mb-2 mt-4">
+  <%= link_to 'Neue Teilnehmer*in anlegen', new_participant_path, class: 'btn btn-primary btn-sm' %>
+</div>
 
 <table id="participants-table" class="table table-sm">
   <thead>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Following the same fix applied to the orders index, this moves the remaining `float-end` "new record" action buttons that sit directly above a DataTable into a flex container (`d-flex justify-content-end`). The DataTable injects a "Suche" search box at the top-right of the table, which previously overlapped/hid these floated buttons.

Only tables initialized as DataTables (`#articles-table`, `#ingredients-table`, `#participants-table`, `#orders-table` — see `app/javascript/datatables.js`) suffer from this overlap. The affected, still-broken occurrences were:

- `app/views/articles/index.html.erb` — "Inventurliste" / "Neuen Artikel anlegen" btn-group above `#articles-table`.
- `app/views/ingredients/show.html.erb` — "Neuen Artikel anlegen" in the *Lieferanten* section above the rendered `#articles-table`.
- `app/views/participants/index.html.erb` — "Neue Teilnehmer*in anlegen" above `#participants-table`.

The orders index (`app/views/orders/_table.html.erb`) and the supplier show article button were already fixed previously. The ingredients index button sits above the page heading (not adjacent to the table) and does not overlap, so it was left unchanged.

## Testing

- `bin/rake spec` — 94 examples, 0 failures.
- Manual GUI testing logged in as `admin@example.com`: verified the action buttons render fully visible above the "Suche" search box on the articles index, participants index, and ingredient show pages.

[new_buttons_visible_above_datatable_search.mp4](https://cursor.com/agents/bc-bc24ede9-aa20-4853-9059-e86de863fe11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnew_buttons_visible_above_datatable_search.mp4)

[Articles index buttons above search](https://cursor.com/agents/bc-bc24ede9-aa20-4853-9059-e86de863fe11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farticles_index_fixed.webp)
[Participants index button above search](https://cursor.com/agents/bc-bc24ede9-aa20-4853-9059-e86de863fe11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fparticipants_index_fixed.webp)
[Ingredient show Lieferanten button above search](https://cursor.com/agents/bc-bc24ede9-aa20-4853-9059-e86de863fe11/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fingredient_show_fixed.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc24ede9-aa20-4853-9059-e86de863fe11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc24ede9-aa20-4853-9059-e86de863fe11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

