### PR TITLE
Show missing article prices in spending views

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Shared view helpers.
 module ApplicationHelper
   def german_list(array)
     [array[0...-1].join(', '), array[-1]].reject(&:blank?).join(' und ')
@@ -20,8 +23,10 @@ module ApplicationHelper
     end
   end
 
-  def euro(price)
-    "#{number_with_delimiter price}\u00A0€"
+  def euro(price, delimiter: nil)
+    options = delimiter ? { delimiter: } : {}
+
+    "#{number_with_delimiter(price, **options)}\u00A0€"
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,11 +3,11 @@
 # Shared view helpers.
 module ApplicationHelper
   def german_list(array)
-    [array[0...-1].join(', '), array[-1]].reject(&:blank?).join(' und ')
+    [array[0...-1].join(', '), array[-1]].compact_blank.join(' und ')
   end
 
   def icon(name)
-    "<img src=\"#{image_path("open-iconic/#{name}.svg")}\" alt=\"icon #{name}\" width=\"16\" height=\"16\">".html_safe
+    tag.img(src: image_path("open-iconic/#{name}.svg"), alt: "icon #{name}", width: 16, height: 16)
   end
 
   def page_title(breadcrumbs)

--- a/app/models/group_box_article_cost.rb
+++ b/app/models/group_box_article_cost.rb
@@ -10,6 +10,11 @@ class GroupBoxArticleCost < ApplicationRecord
   belongs_to :article
 
   scope :final, -> { where(is_final: true) }
+  scope :missing_price, -> { where(unit_price: nil) }
+
+  def missing_price?
+    unit_price.nil?
+  end
 
   def humanize_quantity
     case article.packing_type

--- a/app/models/group_box_article_cost.rb
+++ b/app/models/group_box_article_cost.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Cost calculation row for one article assigned to a group box.
 class GroupBoxArticleCost < ApplicationRecord
   include ActionView::Helpers::NumberHelper
 

--- a/app/models/group_spending.rb
+++ b/app/models/group_spending.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+# Read model for group spending overview and detail pages.
 class GroupSpending
   extend ActiveModel::Translation
   include ActiveModel::Conversion
   include Breadcrumb
 
+  # Read model for the group spending overview matrix.
   class Overview
     def groups
       @groups ||= Group.order(internal_name: :asc, name: :asc).all

--- a/app/models/group_spending.rb
+++ b/app/models/group_spending.rb
@@ -2,6 +2,7 @@
 
 # Read model for group spending overview and detail pages.
 class GroupSpending
+  extend ActiveModel::Naming
   extend ActiveModel::Translation
   include ActiveModel::Conversion
   include Breadcrumb

--- a/app/models/group_spending.rb
+++ b/app/models/group_spending.rb
@@ -25,6 +25,11 @@ class GroupSpending
     def total_totals_by_group
       @total_totals_by_group ||= GroupBoxCost.totals_by_group
     end
+
+    def missing_price_article_counts_by_group
+      @missing_price_article_counts_by_group ||=
+        GroupBoxArticleCost.missing_price.group(:group_id).distinct.count(:article_id)
+    end
   end
 
   def self.overview = Overview.new
@@ -60,6 +65,10 @@ class GroupSpending
 
   def total_estimate
     @total_estimate ||= GroupBoxCost.where(group:).sum(:total_cost)
+  end
+
+  def missing_price_article_count
+    @missing_price_article_count ||= article_costs.select(&:missing_price?).map(&:article_id).uniq.count
   end
 
   def to_param

--- a/app/views/articles/_table.html.erb
+++ b/app/views/articles/_table.html.erb
@@ -1,5 +1,4 @@
-<%# locals: (articles:, ingredient: false, supplier: false, show_price: false, show_base_price: true, order_counts: nil) %>
-<% display_base_price = show_price && show_base_price %>
+<%# locals: (articles:, ingredient: false, supplier: false, show_base_price: true, order_counts: nil) %>
 
 <table id="articles-table" class="table table-sm">
   <thead>
@@ -11,10 +10,8 @@
       <th>Nr.</th>
       <th class="text-end">Lager</th>
       <th class="text-end">Überschuss</th>
-      <% if show_price %>
-        <th class="text-end">Preis</th>
-      <% end %>
-      <% if display_base_price %>
+      <th class="text-end">Preis</th>
+      <% if show_base_price %>
         <th class="text-end">Grundpreis</th>
       <% end %>
       <th class="text-end">max. Bestellmenge</th>
@@ -38,16 +35,14 @@
         <td><%= article.nr %></td>
         <td class="text-end"><%= number_with_delimiter article.stock %></td>
         <td class="text-end"><%= article.surplus %></td>
-        <% if show_price %>
-          <td class="text-end">
-            <% if article.price %>
-              <%= euro article.price %>
-            <% else %>
-              <span class="text-danger fw-semibold">Fehlt</span>
-            <% end %>
-          </td>
-        <% end %>
-        <% if display_base_price %>
+        <td class="text-end">
+          <% if article.price %>
+            <%= euro article.price %>
+          <% else %>
+            <span class="text-danger fw-semibold">Fehlt</span>
+          <% end %>
+        </td>
+        <% if show_base_price %>
           <td class="text-end">
             <% if article.base_price %>
               <%= number_with_precision(article.base_price, precision: 2) %> €/(kg/l/Stk)

--- a/app/views/articles/_table.html.erb
+++ b/app/views/articles/_table.html.erb
@@ -1,3 +1,6 @@
+<% display_price = local_assigns.fetch(:show_price, false) %>
+<% display_base_price = display_price && local_assigns.fetch(:show_base_price, true) %>
+
 <table id="articles-table" class="table table-sm">
   <thead>
     <tr>
@@ -8,9 +11,11 @@
       <th>Nr.</th>
       <th class="text-end">Lager</th>
       <th class="text-end">Überschuss</th>
-      <% if defined?(show_price) %>
-      <th class="text-end">Preis</th>
-      <th class="text-end">Grundpreis</th>
+      <% if display_price %>
+        <th class="text-end">Preis</th>
+      <% end %>
+      <% if display_base_price %>
+        <th class="text-end">Grundpreis</th>
       <% end %>
       <th class="text-end">max. Bestellmenge</th>
       <% if defined?(@order_counts) %><th>Bestellungen</th><% end %>
@@ -33,9 +38,23 @@
         <td><%= article.nr %></td>
         <td class="text-end"><%= number_with_delimiter article.stock %></td>
         <td class="text-end"><%= article.surplus %></td>
-        <% if defined?(show_price) %>
-        <td class="text-end"><%= number_with_delimiter article.price %> €</td>
-        <td class="text-end"><%= number_with_precision(article.base_price, precision: 2) %> €/(kg/l/Stk)</td>
+        <% if display_price %>
+          <td class="text-end">
+            <% if article.price %>
+              <%= euro article.price %>
+            <% else %>
+              <span class="text-danger fw-semibold">Fehlt</span>
+            <% end %>
+          </td>
+        <% end %>
+        <% if display_base_price %>
+          <td class="text-end">
+            <% if article.base_price %>
+              <%= number_with_precision(article.base_price, precision: 2) %> €/(kg/l/Stk)
+            <% else %>
+              —
+            <% end %>
+          </td>
         <% end %>
         <td class="text-end"><%= number_with_delimiter article.order_limit %></td>
         <% if defined?(@order_counts) %><td><%= @order_counts.fetch(article.id, 0) %></td><% end %>

--- a/app/views/articles/_table.html.erb
+++ b/app/views/articles/_table.html.erb
@@ -1,24 +1,24 @@
-<% display_price = local_assigns.fetch(:show_price, false) %>
-<% display_base_price = display_price && local_assigns.fetch(:show_base_price, true) %>
+<%# locals: (articles:, ingredient: false, supplier: false, show_price: false, show_base_price: true, order_counts: nil) %>
+<% display_base_price = show_price && show_base_price %>
 
 <table id="articles-table" class="table table-sm">
   <thead>
     <tr>
       <th>Name</th>
-      <% unless defined?(ingredient) %><th>Warengruppe</th><th>Zutat</th><% end %>
-      <% unless defined?(supplier) %><th>Lieferant</th><% end %>
-      <% if defined?(ingredient) %><th>Prio</th><% end %>
+      <% unless ingredient %><th>Warengruppe</th><th>Zutat</th><% end %>
+      <% unless supplier %><th>Lieferant</th><% end %>
+      <% if ingredient %><th>Prio</th><% end %>
       <th>Nr.</th>
       <th class="text-end">Lager</th>
       <th class="text-end">Überschuss</th>
-      <% if display_price %>
+      <% if show_price %>
         <th class="text-end">Preis</th>
       <% end %>
       <% if display_base_price %>
         <th class="text-end">Grundpreis</th>
       <% end %>
       <th class="text-end">max. Bestellmenge</th>
-      <% if defined?(@order_counts) %><th>Bestellungen</th><% end %>
+      <% if order_counts %><th>Bestellungen</th><% end %>
       <th>Notizen</th>
     </tr>
   </thead>
@@ -27,18 +27,18 @@
     <% articles.each do |article| %>
       <tr>
         <td><%= link_to article %></td>
-        <% unless defined?(ingredient) %>
+        <% unless ingredient %>
           <td><%= article.ingredient.commodity_group %></td>
           <td><%= link_to article.ingredient, article.ingredient %></td>
         <% end %>
-        <% unless defined?(supplier) %>
+        <% unless supplier %>
           <td><%= link_to article.supplier, article.supplier %></td>
         <% end %>
-        <% if defined?(ingredient) %><td><%= article.priority %></td><% end %>
+        <% if ingredient %><td><%= article.priority %></td><% end %>
         <td><%= article.nr %></td>
         <td class="text-end"><%= number_with_delimiter article.stock %></td>
         <td class="text-end"><%= article.surplus %></td>
-        <% if display_price %>
+        <% if show_price %>
           <td class="text-end">
             <% if article.price %>
               <%= euro article.price %>
@@ -57,7 +57,7 @@
           </td>
         <% end %>
         <td class="text-end"><%= number_with_delimiter article.order_limit %></td>
-        <% if defined?(@order_counts) %><td><%= @order_counts.fetch(article.id, 0) %></td><% end %>
+        <% if order_counts %><td><%= order_counts.fetch(article.id, 0) %></td><% end %>
         <td><%= article.notes %></td>
       </tr>
     <% end %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -3,4 +3,4 @@
   <%= link_to 'Neuen Artikel anlegen', new_article_path, class: 'btn btn-sm btn-primary' %>
 </div>
 
-<%= render 'table', articles: @articles %>
+<%= render 'table', articles: @articles, show_price: true, show_base_price: false %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -3,4 +3,4 @@
   <%= link_to 'Neuen Artikel anlegen', new_article_path, class: 'btn btn-sm btn-primary' %>
 </div>
 
-<%= render 'table', articles: @articles, show_price: true, show_base_price: false, order_counts: @order_counts %>
+<%= render 'table', articles: @articles, show_base_price: false, order_counts: @order_counts %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -3,4 +3,4 @@
   <%= link_to 'Neuen Artikel anlegen', new_article_path, class: 'btn btn-sm btn-primary' %>
 </div>
 
-<%= render 'table', articles: @articles, show_price: true, show_base_price: false %>
+<%= render 'table', articles: @articles, show_price: true, show_base_price: false, order_counts: @order_counts %>

--- a/app/views/group_box_article_costs/_table.html.erb
+++ b/app/views/group_box_article_costs/_table.html.erb
@@ -9,11 +9,23 @@
   </thead>
   <tbody>
     <% article_costs.each do |article_cost| %>
-      <tr>
+      <tr class="<%= 'table-danger' if article_cost.missing_price? %>">
         <td><%= link_to article_cost.article.packing_name, article_cost.article %></td>
         <td class="text-end"><%= article_cost.humanize_quantity %></td>
-        <td class="text-end"><%= euro article_cost.unit_price %></td>
-        <td class="text-end"><%= euro article_cost.line_total %></td>
+        <td class="text-end">
+          <% if article_cost.missing_price? %>
+            <span class="fw-semibold">Fehlt</span>
+          <% else %>
+            <%= euro article_cost.unit_price %>
+          <% end %>
+        </td>
+        <td class="text-end">
+          <% if article_cost.missing_price? %>
+            —
+          <% else %>
+            <%= euro article_cost.line_total %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>
@@ -21,7 +33,7 @@
     <tfoot>
       <tr>
         <th colspan="3" class="text-end">Summe</th>
-        <th class="text-end"><%= euro article_costs.sum(&:line_total) %></th>
+        <th class="text-end"><%= euro article_costs.filter_map(&:line_total).sum %></th>
       </tr>
     </tfoot>
   <% end %>

--- a/app/views/group_box_article_costs/_table.html.erb
+++ b/app/views/group_box_article_costs/_table.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (article_costs:, show_total: true) %>
+
 <table class="table table-sm">
   <thead>
     <tr>
@@ -29,7 +31,7 @@
       </tr>
     <% end %>
   </tbody>
-  <% if local_assigns.fetch(:show_total, true) %>
+  <% if show_total %>
     <tfoot>
       <tr>
         <th colspan="3" class="text-end">Summe</th>

--- a/app/views/group_spendings/index.html.erb
+++ b/app/views/group_spendings/index.html.erb
@@ -44,7 +44,7 @@
             <% cost = @group_spending_overview.costs_by_group_and_box[[group.id, box.id]] %>
             <td class="text-end <%= box.packed? ? 'table-success' : 'table-warning' %>">
               <% if cost&.total_cost %>
-                <%= link_to euro(cost.total_cost), box_group_path(box, group, anchor: 'costs'),
+                <%= link_to euro(cost.total_cost, delimiter: '.'), box_group_path(box, group, anchor: 'costs'),
                             class: box.packed? ? 'text-success-emphasis' : 'text-warning-emphasis' %>
               <% else %>
                 —
@@ -54,7 +54,7 @@
           <td class="text-end table-success fw-semibold">
             <% final_total = @group_spending_overview.final_totals_by_group[group.id] %>
             <% if final_total %>
-              <%= euro final_total %>
+              <%= euro final_total, delimiter: '.' %>
             <% else %>
               —
             <% end %>
@@ -62,7 +62,7 @@
           <td class="text-end table-warning fw-semibold">
             <% total = @group_spending_overview.total_totals_by_group[group.id] %>
             <% if total %>
-              <%= link_to euro(total), group_spending_path(group), class: 'text-warning-emphasis' %>
+              <%= link_to euro(total, delimiter: '.'), group_spending_path(group), class: 'text-warning-emphasis' %>
             <% else %>
               —
             <% end %>

--- a/app/views/group_spendings/index.html.erb
+++ b/app/views/group_spendings/index.html.erb
@@ -7,6 +7,7 @@
 <div class="mb-3">
   <span class="badge text-bg-success me-2">Endgültig</span> Kiste bereits ausgegeben (Packstraße)
   <span class="badge text-bg-warning ms-3 me-2">Geschätzt</span> Kiste noch in Planung
+  <span class="badge text-bg-danger ms-3 me-2">Preis fehlt</span> Kochgruppe enthält Artikel ohne Preis
 </div>
 
 <div class="table-responsive">
@@ -27,12 +28,22 @@
 
     <tbody>
       <% @group_spending_overview.groups.each do |group| %>
+        <% missing_price_count = @group_spending_overview.missing_price_article_counts_by_group.fetch(group.id, 0) %>
         <tr>
-          <td><%= group.display_name %></td>
+          <td>
+            <%= group.display_name %>
+            <% if missing_price_count.positive? %>
+              <%= link_to group_spending_path(group),
+                          class: 'badge text-bg-danger ms-2 text-decoration-none',
+                          title: "#{missing_price_count} Artikel ohne Preis" do %>
+                <%= missing_price_count %> ohne Preis
+              <% end %>
+            <% end %>
+          </td>
           <% @group_spending_overview.boxes.each do |box| %>
             <% cost = @group_spending_overview.costs_by_group_and_box[[group.id, box.id]] %>
             <td class="text-end <%= box.packed? ? 'table-success' : 'table-warning' %>">
-              <% if cost %>
+              <% if cost&.total_cost %>
                 <%= link_to euro(cost.total_cost), box_group_path(box, group, anchor: 'costs'),
                             class: box.packed? ? 'text-success-emphasis' : 'text-warning-emphasis' %>
               <% else %>

--- a/app/views/group_spendings/show.html.erb
+++ b/app/views/group_spendings/show.html.erb
@@ -15,6 +15,13 @@
   </div>
 </div>
 
+<% if @group_spending.missing_price_article_count.positive? %>
+  <div class="alert alert-danger">
+    <strong>Preis fehlt:</strong>
+    <%= @group_spending.missing_price_article_count %> Artikel in dieser Kochgruppe haben keinen Preis und sind unten markiert.
+  </div>
+<% end %>
+
 <% if @group_spending.costs_by_box.any? %>
   <% @group_spending.costs_by_box.each do |box, article_costs| %>
     <h2 class="h5 mt-4">

--- a/app/views/ingredients/show.html.erb
+++ b/app/views/ingredients/show.html.erb
@@ -69,7 +69,7 @@
 <h2>Lieferanten</h2>
 
 <%= link_to 'Neuen Artikel anlegen', new_article_path(ingredient_id: @ingredient), class: 'btn btn-sm btn-primary float-end' %>
-<%= render 'articles/table', articles: @ingredient.articles, ingredient: true, show_price: true %>
+<%= render 'articles/table', articles: @ingredient.articles, ingredient: true %>
 
 <table class="table table-sm">
   <thead>

--- a/db/migrate/20260604062000_update_group_box_article_costs_to_version_2.rb
+++ b/db/migrate/20260604062000_update_group_box_article_costs_to_version_2.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Keeps cost rows visible when article prices are missing.
+class UpdateGroupBoxArticleCostsToVersion2 < ActiveRecord::Migration[8.0]
+  def change
+    update_view :group_box_article_costs, version: 2, revert_to_version: 1
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -485,7 +485,7 @@ CREATE VIEW public.group_box_article_costs AS
    FROM ((public.group_box_articles
      JOIN public.articles ON ((articles.id = group_box_articles.article_id)))
      JOIN public.boxes ON ((boxes.id = group_box_articles.box_id)))
-  WHERE ((group_box_articles.quantity <> (0)::numeric) AND (articles.price IS NOT NULL));
+   WHERE (group_box_articles.quantity <> (0)::numeric);
 
 
 --
@@ -2941,6 +2941,7 @@ ALTER TABLE ONLY public.missing_ingredients
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260604062000'),
 ('20260529120000'),
 ('20260103203508'),
 ('20250223161014'),

--- a/db/views/group_box_article_costs_v02.sql
+++ b/db/views/group_box_article_costs_v02.sql
@@ -1,0 +1,13 @@
+SELECT
+  group_box_articles.id AS group_box_article_id,
+  group_box_articles.group_id,
+  group_box_articles.box_id,
+  group_box_articles.article_id,
+  group_box_articles.quantity,
+  articles.price AS unit_price,
+  ROUND((group_box_articles.quantity * articles.price)::numeric, 2) AS line_total,
+  (boxes.status = 2) AS is_final
+FROM group_box_articles
+JOIN articles ON articles.id = group_box_articles.article_id
+JOIN boxes ON boxes.id = group_box_articles.box_id
+WHERE group_box_articles.quantity <> 0;

--- a/spec/models/group_box_cost_spec.rb
+++ b/spec/models/group_box_cost_spec.rb
@@ -7,13 +7,16 @@ RSpec.describe GroupBoxCost do
   let(:article) { create(:article, price: 4, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:packed_box) { create(:box, :packed) }
   let(:planned_box) { create(:box) }
-  let(:zero_article) { create(:article, price: 3, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
 
   before do
     create(:group_box_article, group:, box: packed_box, article:, quantity: 2)
     create(:group_box_article, group:, box: planned_box, article:, quantity: 1)
-    create(:group_box_article, group:, box: planned_box, article: zero_article, quantity: 0)
+    create(:group_box_article,
+           group:,
+           box: planned_box,
+           article: create(:article, price: 3, unit: 'g', packing_type: :piece, quantity: 500),
+           quantity: 0)
     create(:group_box_article, group:, box: planned_box, article: missing_price_article, quantity: 1)
   end
 
@@ -24,18 +27,22 @@ RSpec.describe GroupBoxCost do
     expect(article_cost.is_final).to be(true)
   end
 
-  it 'aggregates totals per group and box', :aggregate_failures do
+  it 'aggregates final totals per group and box', :aggregate_failures do
     packed_cost = described_class.find_by(group:, box: packed_box)
-    planned_cost = described_class.find_by(group:, box: planned_box)
 
     expect(packed_cost.total_cost).to eq(8)
     expect(packed_cost.is_final).to be(true)
+  end
+
+  it 'aggregates planned totals per group and box', :aggregate_failures do
+    planned_cost = described_class.find_by(group:, box: planned_box)
+
     expect(planned_cost.total_cost).to eq(4)
     expect(planned_cost.is_final).to be(false)
   end
 
   it 'excludes zero-quantity rows' do
-    expect(GroupBoxArticleCost.where(article: zero_article)).to be_empty
+    expect(GroupBoxArticleCost.pluck(:quantity)).not_to include(0)
   end
 
   it 'exposes rows with missing article prices', :aggregate_failures do

--- a/spec/models/group_box_cost_spec.rb
+++ b/spec/models/group_box_cost_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe GroupBoxCost do
   let(:packed_box) { create(:box, :packed) }
   let(:planned_box) { create(:box) }
   let(:zero_article) { create(:article, price: 3, unit: 'g', packing_type: :piece, quantity: 500) }
+  let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
 
   before do
     create(:group_box_article, group:, box: packed_box, article:, quantity: 2)
     create(:group_box_article, group:, box: planned_box, article:, quantity: 1)
     create(:group_box_article, group:, box: planned_box, article: zero_article, quantity: 0)
+    create(:group_box_article, group:, box: planned_box, article: missing_price_article, quantity: 1)
   end
 
   it 'calculates line totals from current article prices', :aggregate_failures do
@@ -33,6 +35,14 @@ RSpec.describe GroupBoxCost do
   end
 
   it 'excludes zero-quantity rows' do
-    expect(GroupBoxArticleCost.count).to eq(2)
+    expect(GroupBoxArticleCost.where(article: zero_article)).to be_empty
+  end
+
+  it 'exposes rows with missing article prices', :aggregate_failures do
+    article_cost = GroupBoxArticleCost.find_by(group:, box: planned_box, article: missing_price_article)
+
+    expect(article_cost).to be_missing_price
+    expect(article_cost.line_total).to be_nil
+    expect(GroupBoxArticleCost.missing_price).to contain_exactly(article_cost)
   end
 end

--- a/spec/models/group_spending_spec.rb
+++ b/spec/models/group_spending_spec.rb
@@ -5,10 +5,12 @@ require 'rails_helper'
 RSpec.describe GroupSpending do
   let(:group) { create(:group) }
   let(:article) { create(:article, price: 4, unit: 'g', packing_type: :piece, quantity: 500) }
+  let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:packed_box) { create(:box, :packed) }
 
   before do
     create(:group_box_article, group:, box: packed_box, article:, quantity: 2)
+    create(:group_box_article, group:, box: packed_box, article: missing_price_article, quantity: 1)
   end
 
   describe '.overview' do
@@ -18,6 +20,7 @@ RSpec.describe GroupSpending do
       expect(overview).to be_a(described_class::Overview)
       expect(overview.groups).to include(group)
       expect(overview.final_totals_by_group[group.id]).to eq(8)
+      expect(overview.missing_price_article_counts_by_group[group.id]).to eq(1)
     end
   end
 
@@ -28,6 +31,7 @@ RSpec.describe GroupSpending do
       expect(spending.group).to eq(group)
       expect(spending.final_total).to eq(8)
       expect(spending.costs_by_box.keys).to eq([packed_box])
+      expect(spending.missing_price_article_count).to eq(1)
     end
   end
 

--- a/spec/models/group_spending_spec.rb
+++ b/spec/models/group_spending_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe GroupSpending do
   end
 
   describe '#spending on Group' do
-    it 'wraps the group' do
+    it 'wraps the group', :aggregate_failures do
       expect(group.spending).to be_a(described_class)
       expect(group.spending.final_total).to eq(8)
     end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -10,17 +10,24 @@ RSpec.describe 'Articles' do
   end
 
   describe 'GET /articles' do
-    it 'shows article prices and marks missing prices', :aggregate_failures do
-      create(:article, price: 2.5)
-      create(:article, price: nil)
+    before do
+      create(:article, price: 2.5, unit: 'g', packing_type: :piece, quantity: 500)
+      create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500)
+    end
 
+    it 'shows article prices', :aggregate_failures do
       get articles_path
 
       expect(response).to have_http_status(:success)
       expect(response.body).to include('Preis')
       expect(response.body).to include("2,5\u00A0€")
-      expect(response.body).to include('Fehlt')
       expect(response.body).not_to include('Grundpreis')
+    end
+
+    it 'marks missing prices' do
+      get articles_path
+
+      expect(response.body).to include('Fehlt')
     end
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -34,12 +34,13 @@ RSpec.describe 'Articles' do
   end
 
   describe 'shared article table' do
+    before { GroupBoxIngredientUnitCache.do_calculate }
+
     it 'shows price and base price on ingredient pages', :aggregate_failures do
       create(:article, supplier:, ingredient:, price: 2.5, unit: 'g', packing_type: :piece, quantity: 500)
 
       get ingredient_path(ingredient)
 
-      expect(response).to have_http_status(:success)
       expect(response.body).to include('Preis')
       expect(response.body).to include('Grundpreis')
       expect(response.body).to include("2,5\u00A0€")
@@ -50,7 +51,6 @@ RSpec.describe 'Articles' do
 
       get supplier_path(supplier)
 
-      expect(response).to have_http_status(:success)
       expect(response.body).to include('Preis')
       expect(response.body).to include('Grundpreis')
       expect(response.body).to include('Fehlt')

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe 'Articles' do
   let(:user) { create(:user, role: :office) }
+  let(:supplier) { create(:supplier) }
+  let(:ingredient) { create(:ingredient) }
 
   before do
     sign_in user, scope: :user
@@ -27,6 +29,30 @@ RSpec.describe 'Articles' do
     it 'marks missing prices' do
       get articles_path
 
+      expect(response.body).to include('Fehlt')
+    end
+  end
+
+  describe 'shared article table' do
+    it 'shows price and base price on ingredient pages', :aggregate_failures do
+      create(:article, supplier:, ingredient:, price: 2.5, unit: 'g', packing_type: :piece, quantity: 500)
+
+      get ingredient_path(ingredient)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('Preis')
+      expect(response.body).to include('Grundpreis')
+      expect(response.body).to include("2,5\u00A0€")
+    end
+
+    it 'shows missing prices on supplier pages', :aggregate_failures do
+      create(:article, supplier:, ingredient:, price: nil, unit: 'g', packing_type: :piece, quantity: 500)
+
+      get supplier_path(supplier)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('Preis')
+      expect(response.body).to include('Grundpreis')
       expect(response.body).to include('Fehlt')
     end
   end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Articles' do
+  let(:user) { create(:user, role: :office) }
+
+  before do
+    sign_in user, scope: :user
+  end
+
+  describe 'GET /articles' do
+    it 'shows article prices and marks missing prices', :aggregate_failures do
+      create(:article, price: 2.5)
+      create(:article, price: nil)
+
+      get articles_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('Preis')
+      expect(response.body).to include("2,5\u00A0€")
+      expect(response.body).to include('Fehlt')
+      expect(response.body).not_to include('Grundpreis')
+    end
+  end
+end

--- a/spec/requests/group_spending_spec.rb
+++ b/spec/requests/group_spending_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Group spendings' do
   let(:group) { create(:group) }
-  let(:article) { create(:article, price: 2.5, unit: 'g', packing_type: :piece, quantity: 500) }
+  let(:article) { create(:article, price: 1250.5, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:packed_box) { create(:box, :packed, datetime: 1.day.ago) }
   let(:planned_box) { create(:box, datetime: 1.day.from_now) }
@@ -28,8 +28,8 @@ RSpec.describe 'Group spendings' do
         get group_spendings_path
 
         expect(response.body).to include('Kostenübersicht')
-        expect(response.body).to include("5,0\u00A0€")
-        expect(response.body).to include("7,5\u00A0€")
+        expect(response.body).to include("2.501,0\u00A0€")
+        expect(response.body).to include("3.751,5\u00A0€")
         expect(response.body).to include('1 ohne Preis')
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe 'Group spendings' do
 
         expect(response.body).to include(group.display_name)
         expect(response.body).to include('Summe endgültig')
-        expect(response.body).to include("5,0\u00A0€")
-        expect(response.body).to include("12,5\u00A0€")
+        expect(response.body).to include("2 501,0\u00A0€")
+        expect(response.body).to include("6 252,5\u00A0€")
       end
 
       it 'shows and highlights missing-price articles', :aggregate_failures do

--- a/spec/requests/group_spending_spec.rb
+++ b/spec/requests/group_spending_spec.rb
@@ -5,12 +5,14 @@ require 'rails_helper'
 RSpec.describe 'Group spendings' do
   let(:group) { create(:group) }
   let(:article) { create(:article, price: 2.5, unit: 'g', packing_type: :piece, quantity: 500) }
+  let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:packed_box) { create(:box, :packed, datetime: 1.day.ago) }
   let(:planned_box) { create(:box, datetime: 1.day.from_now) }
 
   before do
     create(:group_box_article, group:, box: packed_box, article:, quantity: 2)
     create(:group_box_article, group:, box: planned_box, article:, quantity: 3)
+    create(:group_box_article, group:, box: planned_box, article: missing_price_article, quantity: 1)
   end
 
   describe 'GET /group_spendings' do
@@ -30,6 +32,7 @@ RSpec.describe 'Group spendings' do
         expect(response.body).to include('Kostenübersicht')
         expect(response.body).to include("5,0\u00A0€")
         expect(response.body).to include("7,5\u00A0€")
+        expect(response.body).to include('1 ohne Preis')
       end
     end
 
@@ -63,6 +66,9 @@ RSpec.describe 'Group spendings' do
         expect(response.body).to include('Summe endgültig')
         expect(response.body).to include("5,0\u00A0€")
         expect(response.body).to include("12,5\u00A0€")
+        expect(response.body).to include('Preis fehlt:')
+        expect(response.body).to include(missing_price_article.packing_name)
+        expect(response.body).to include('table-danger')
       end
     end
   end

--- a/spec/requests/group_spending_spec.rb
+++ b/spec/requests/group_spending_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe 'Group spendings' do
 
   describe 'GET /group_spendings' do
     context 'when signed in as office user' do
-      let(:user) { create(:user, role: :office) }
-
-      before { sign_in user, scope: :user }
+      before { sign_in create(:user, role: :office), scope: :user }
 
       it 'returns a successful response' do
         get group_spendings_path
@@ -37,9 +35,7 @@ RSpec.describe 'Group spendings' do
     end
 
     context 'when signed in as read-only user' do
-      let(:user) { create(:user, role: :read_only) }
-
-      before { sign_in user, scope: :user }
+      before { sign_in create(:user, role: :read_only), scope: :user }
 
       it 'denies access' do
         get group_spendings_path
@@ -50,9 +46,7 @@ RSpec.describe 'Group spendings' do
 
   describe 'GET /group_spendings/:group_id' do
     context 'when signed in as office user' do
-      let(:user) { create(:user, role: :office) }
-
-      before { sign_in user, scope: :user }
+      before { sign_in create(:user, role: :office), scope: :user }
 
       it 'returns a successful response' do
         get group_spending_path(group)
@@ -66,6 +60,11 @@ RSpec.describe 'Group spendings' do
         expect(response.body).to include('Summe endgültig')
         expect(response.body).to include("5,0\u00A0€")
         expect(response.body).to include("12,5\u00A0€")
+      end
+
+      it 'shows and highlights missing-price articles', :aggregate_failures do
+        get group_spending_path(group)
+
         expect(response.body).to include('Preis fehlt:')
         expect(response.body).to include(missing_price_article.packing_name)
         expect(response.body).to include('table-danger')

--- a/spec/requests/group_spending_spec.rb
+++ b/spec/requests/group_spending_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Group spendings' do
   let(:group) { create(:group) }
-  let(:article) { create(:article, price: 1250.5, unit: 'g', packing_type: :piece, quantity: 500) }
+  let(:article) { create(:article, price: 625.25, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:missing_price_article) { create(:article, price: nil, unit: 'g', packing_type: :piece, quantity: 500) }
   let(:packed_box) { create(:box, :packed, datetime: 1.day.ago) }
   let(:planned_box) { create(:box, datetime: 1.day.from_now) }
@@ -28,8 +28,8 @@ RSpec.describe 'Group spendings' do
         get group_spendings_path
 
         expect(response.body).to include('Kostenübersicht')
-        expect(response.body).to include("2.501,0\u00A0€")
-        expect(response.body).to include("3.751,5\u00A0€")
+        expect(response.body).to include("1.250,5\u00A0€")
+        expect(response.body).to include("1.875,75\u00A0€")
         expect(response.body).to include('1 ohne Preis')
       end
     end
@@ -58,8 +58,8 @@ RSpec.describe 'Group spendings' do
 
         expect(response.body).to include(group.display_name)
         expect(response.body).to include('Summe endgültig')
-        expect(response.body).to include("2 501,0\u00A0€")
-        expect(response.body).to include("6 252,5\u00A0€")
+        expect(response.body).to include("1 250,5\u00A0€")
+        expect(response.body).to include("3 126,25\u00A0€")
       end
 
       it 'shows and highlights missing-price articles', :aggregate_failures do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add price visibility to the article index and mark missing article prices.
- Warn on the group spending overview when a group has articles without prices.
- Keep missing-price articles in spending detail tables, highlight those rows, and fix the detail breadcrumb naming issue.
- Add a view migration so cost rows with missing prices remain visible.
- Format group spending overview amounts with dot thousands separators for Excel import.
- Use Rails strict locals with defaults in the shared article and cost table ERB partials.
- Simplify the shared article table so price is always shown; only base-price and order-count columns remain optional.

### Walkthrough
[missing_article_prices_clean_walkthrough.mp4](https://cursor.com/agents/bc-38ddd082-0d83-4651-a48f-1bd024093536/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmissing_article_prices_clean_walkthrough.mp4)
[group_spending_dot_thousands_separator.mp4](https://cursor.com/agents/bc-38ddd082-0d83-4651-a48f-1bd024093536/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgroup_spending_dot_thousands_separator.mp4)
[article_table_strict_locals_simplification.mp4](https://cursor.com/agents/bc-38ddd082-0d83-4651-a48f-1bd024093536/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Farticle_table_strict_locals_simplification.mp4)

### Testing
- Passed focused spending/article specs.
- Passed full `bin/rake spec` suite.
- Passed RuboCop on changed Ruby spec files.
- Manually verified article index, ingredient detail, and supplier detail table rendering.
- Full `bin/rubocop` still reports existing repo-wide baseline offenses outside this change.
- Raw `.erb` paths are not parseable by the current RuboCop setup; no ERB-aware linter is configured.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38ddd082-0d83-4651-a48f-1bd024093536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38ddd082-0d83-4651-a48f-1bd024093536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

