### PR TITLE
Run database migrations on Docker container boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,7 @@ RUN apk --update --no-cache upgrade && rm -rf /var/cache/apk/*
 
 EXPOSE 3000
 
+RUN chmod +x bin/docker-entrypoint.sh
+
+ENTRYPOINT ["bin/docker-entrypoint.sh"]
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+case "${DISABLE_DB_MIGRATE}" in
+  true|TRUE|1|yes|YES)
+    ;;
+  *)
+    echo "Running database migrations..."
+    bundle exec rails db:migrate
+    ;;
+esac
+
+exec "$@"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docker deployments no longer need a separate migration step before starting the app. The container runs `rails db:migrate` on boot by default, then starts Puma.

## Changes

- Add `bin/docker-entrypoint.sh` that runs migrations before the main process
- Wire the script as the Docker `ENTRYPOINT` in `Dockerfile`

## Opt-out

Set `DISABLE_DB_MIGRATE` to disable automatic migrations when needed (e.g. dedicated migration job, or multiple replicas where only one should migrate):

```bash
DISABLE_DB_MIGRATE=true   # also accepts 1, yes (case-insensitive for true/yes)
```

## Usage

Default (migrations run on boot):

```bash
docker run -e DATABASE_URL=... ghcr.io/buenaventure/verkel
```

Skip migrations:

```bash
docker run -e DISABLE_DB_MIGRATE=true -e DATABASE_URL=... ghcr.io/buenaventure/verkel
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-661c71ea-0656-409c-8eac-73592fb44dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-661c71ea-0656-409c-8eac-73592fb44dcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

