### PR TITLE
Fix group_box_article_costs migration view dependency

### DIFF
--- a/db/migrate/20260604062000_update_group_box_article_costs_to_version_2.rb
+++ b/db/migrate/20260604062000_update_group_box_article_costs_to_version_2.rb
@@ -3,6 +3,8 @@
 # Keeps cost rows visible when article prices are missing.
 class UpdateGroupBoxArticleCostsToVersion2 < ActiveRecord::Migration[8.0]
   def change
+    drop_view :group_box_costs, revert_to_version: 1
     update_view :group_box_article_costs, version: 2, revert_to_version: 1
+    create_view :group_box_costs, version: 1
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Migration `20260604062000_update_group_box_article_costs_to_version_2` fails with:

```
PG::DependentObjectsStillExist: ERROR: cannot drop view group_box_article_costs because other objects depend on it
DETAIL: view group_box_costs depends on view group_box_article_costs
```

Scenic's `update_view` drops and recreates the view, but PostgreSQL refuses to drop `group_box_article_costs` while `group_box_costs` still references it.

## Solution

Follow the same pattern used in `20250222095439_change_quantity_precision.rb` for dependent Scenic views:

1. Drop the dependent `group_box_costs` view first
2. Update `group_box_article_costs` to version 2
3. Recreate `group_box_costs` at version 1

`revert_to_version: 1` is included on `drop_view` so the migration remains reversible.

## Testing

- Simulated pre-migration state (v1 views) and ran `bin/rails db:migrate` successfully
- Verified `bin/rails db:rollback STEP=1` and re-migrate both succeed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc9798ac-84cf-4273-b21f-79abb2ab49dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc9798ac-84cf-4273-b21f-79abb2ab49dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

