### PR TITLE
Bump puma to 8.0.2 to fix Dependabot security alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'ostruct'
 gem 'pg'
 gem 'prawn'
 gem 'prawn-table'
-gem 'puma', '~> 6.0'
+gem 'puma', '~> 8.0'
 gem 'rails', '~> 8.0.0'
 gem 'rails-i18n', '~> 8.0.0'
 gem 'roo', '~> 2.10.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -536,7 +536,7 @@ DEPENDENCIES
   pg
   prawn
   prawn-table
-  puma (~> 6.0)
+  puma (~> 8.0)
   rack-mini-profiler (~> 3.3)
   rails (~> 8.0.0)
   rails-i18n (~> 8.0.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates **puma** from 6.6.1 to 8.0.2 to resolve open Dependabot security alerts:

- **CVE-2026-47736** (GHSA-qpgp-93vx-g8v8): PROXY Protocol v1 parser allows remote memory exhaustion
- **CVE-2026-47737** (GHSA-2vqw-3mp8-cgmx): PROXY Protocol v1 accepts repeated protocol headers on persistent connections

## Changes

- `Gemfile`: relax puma constraint from `~> 6.0` to `~> 8.0`
- `Gemfile.lock`: puma 6.6.1 → 8.0.2

## Verification

- `bundle audit check` — no vulnerabilities found
- `yarn audit` — no vulnerabilities found
- `bin/rake spec` — 101 examples, 0 failures
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ac96766-2b03-475c-ade7-9c060cf8b4b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ac96766-2b03-475c-ade7-9c060cf8b4b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

